### PR TITLE
vuexが渡されなくても使えるように

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,13 +1,17 @@
-import store from "./store"; // Vuex toasts module
+import Vuex from "vuex";
+import whimStore from "./store"; // Vuex toasts module
 
 export default {
-  install(Vue: any, options: any): void {
-    if (!options.store) {
-      throw new Error("Please provide vuex store.");
+  install(Vue: any, options?: any): void {
+    let store = options?.store;
+    if (!store) {
+      Vue.use(Vuex);
+      store = new Vuex.Store({});
+      // throw new Error("Please rovide vuex store.");
     }
 
     // Register vuex module
-    options.store.registerModule("whimClient", store);
+    store.registerModule("whimClient", whimStore);
 
     // wh.im本体との通信を開始
     window.parent.postMessage("connect", document.referrer);
@@ -17,19 +21,19 @@ export default {
       "message",
       (event) => {
         if (event.data.room) {
-          options.store.commit("whimClient/setRoom", event.data.room);
+          store.commit("whimClient/setRoom", event.data.room);
         }
         if (event.data.accessUserId) {
-          options.store.commit(
+          store.commit(
             "whimClient/setAccessUserId",
             event.data.accessUserId,
           );
         }
         if (event.data.users) {
-          options.store.commit("whimClient/setUsers", event.data.users);
+          store.commit("whimClient/setUsers", event.data.users);
         }
         if (event.data.appState) {
-          options.store.commit("whimClient/setAppState", event.data.appState);
+          store.commit("whimClient/setAppState", event.data.appState);
         }
       },
       false,
@@ -37,43 +41,43 @@ export default {
 
     const prototypeWhim = {
       assignState(obj: { [s: string]: any }) {
-        return options.store.dispatch("whimClient/assignState", obj);
+        return store.dispatch("whimClient/assignState", obj);
       },
 
       replaceState(obj: { [s: string]: any }) {
-        return options.store.dispatch("whimClient/replaceState", obj);
+        return store.dispatch("whimClient/replaceState", obj);
       },
 
       deleteState() {
-        return options.store.dispatch("whimClient/deleteState");
+        return store.dispatch("whimClient/deleteState");
       },
     };
 
     Object.defineProperty(prototypeWhim, "users", {
       enumerable: true,
       get: () => {
-        return options.store.getters["whimClient/users"];
+        return store.getters["whimClient/users"];
       },
     });
 
     Object.defineProperty(prototypeWhim, "accessUser", {
       enumerable: true,
       get: () => {
-        return options.store.getters["whimClient/accessUser"];
+        return store.getters["whimClient/accessUser"];
       },
     });
 
     Object.defineProperty(prototypeWhim, "room", {
       enumerable: true,
       get: () => {
-        return options.store.getters["whimClient/room"];
+        return store.getters["whimClient/room"];
       },
     });
 
     Object.defineProperty(prototypeWhim, "state", {
       enumerable: true,
       get: () => {
-        return options.store.getters["whimClient/appState"];
+        return store.getters["whimClient/appState"];
       },
     });
 


### PR DESCRIPTION
fix #4 

ゲーム側から Vuex が渡されなかったら、自動で生成する。
ゲームの実装がこんな感じになる
```main.js
import Vue from "vue";
import App from "./App.vue";
import whimClientVue from "whim-client-vue";

Vue.config.productionTip = false;
Vue.use(whimClientVue);

new Vue({
  render: h => h(App)
}).$mount("#app");
```