### PR TITLE
配列をindex指定で更新できるように

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,3 +1,5 @@
+import mergeDeeply from "../utils/merge_deeply";
+
 interface Room {
   id?: string;
 }
@@ -22,28 +24,6 @@ type ConnFunc = (prop: string, obj: { [s: string]: any }) => void;
 interface PathValue {
   // eslint-disable-next-line
   [key: string]: any;
-}
-
-// eslint-disable-next-line
-function mergeDeeply(target: any, source: any) {
-  // eslint-disable-next-line
-  const isObject = (obj: any) =>
-    obj && typeof obj === "object" && !Array.isArray(obj);
-  const result = Object.assign({}, target);
-  if (isObject(target) && isObject(source)) {
-    for (const [sourceKey, sourceValue] of Object.entries(source)) {
-      const targetValue = target[sourceKey];
-      if (
-        isObject(sourceValue) &&
-        Object.prototype.hasOwnProperty.call(target, sourceKey)
-      ) {
-        result[sourceKey] = mergeDeeply(targetValue, sourceValue);
-      } else {
-        Object.assign(result, { [sourceKey]: sourceValue });
-      }
-    }
-  }
-  return result;
 }
 
 // eslint-disable-next-line

--- a/src/utils/merge_deeply.ts
+++ b/src/utils/merge_deeply.ts
@@ -12,13 +12,10 @@ function mergeDeeply(target: any, source: any): any {
 
       if (
         isObject(sourceValue) &&
+        isObject(targetValue) &&
         Object.prototype.hasOwnProperty.call(target, sourceKey)
       ) {
-        if (isObject(targetValue)) {
-          resultArray[sourceKey] = mergeDeeply(targetValue, sourceValue);
-        } else {
-          resultArray[sourceKey] = sourceValue;
-        }
+        resultArray[sourceKey] = mergeDeeply(targetValue, sourceValue);
       } else {
         resultArray[sourceKey] = sourceValue;
       }

--- a/src/utils/merge_deeply.ts
+++ b/src/utils/merge_deeply.ts
@@ -1,0 +1,44 @@
+// eslint-disable-next-line
+function mergeDeeply(target: any, source: any): any {
+  // eslint-disable-next-line
+  const isObject = (obj: any) =>
+    obj && typeof obj === "object" && !Array.isArray(obj);
+  const result = Object.assign({}, target);
+  if (Array.isArray(target) && isObject(source)) {
+    const resultArray = JSON.parse(JSON.stringify(target));
+    for (const [sourceKey, sourceValue] of Object.entries(source)) {
+      // @ts-ignore
+      const targetValue = target[sourceKey];
+
+      if (
+        isObject(sourceValue) &&
+        Object.prototype.hasOwnProperty.call(target, sourceKey)
+      ) {
+        if (isObject(targetValue)) {
+          resultArray[sourceKey] = mergeDeeply(targetValue, sourceValue);
+        } else {
+          resultArray[sourceKey] = sourceValue;
+        }
+      } else {
+        resultArray[sourceKey] = sourceValue;
+      }
+    }
+    return resultArray;
+  }
+  if (isObject(target) && isObject(source)) {
+    for (const [sourceKey, sourceValue] of Object.entries(source)) {
+      const targetValue = target[sourceKey];
+      if (
+        isObject(sourceValue) &&
+        Object.prototype.hasOwnProperty.call(target, sourceKey)
+      ) {
+        result[sourceKey] = mergeDeeply(targetValue, sourceValue);
+      } else {
+        Object.assign(result, { [sourceKey]: sourceValue });
+      }
+    }
+  }
+  return result;
+}
+
+export default mergeDeeply;


### PR DESCRIPTION
# Summary
配列をindex指定で更新できるようにした。

例
```js
console.log(this.$whim.state) // => { a: [1, 2, { b: 1, c:2 }] }

this.$whim.assignState({ a: { 2: { b: 0 }}})

console.log(this.$whim.state) // => { a: [1, 2, { b: 0, c:2 }] }
```